### PR TITLE
Specify that CSC only works with Steam in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Custom Servers Client
-In-game client for custom servers for Among Us
+An in-game client for custom servers for Among Us. This only works with the Steam version of the game.
 
 ## Screenshot
 ![screenshot_0](https://cdn.discordapp.com/attachments/759066383090188308/763331715740729364/unknown.png)


### PR DESCRIPTION
Just a small README change to specify that this only works with the Steam builds of the game. Though you specify the version `v2020.10.22s` with the `s` being there, it isn't totally clear which version this applies to if you don't know that the `s` means Steam. 